### PR TITLE
add retry logic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,15 +26,17 @@
   ],
   "require": {
     "php": "^8.1",
-    "ext-json": "*",
     "ext-curl": "*",
+    "ext-json": "*",
+    "caseyamcl/guzzle_retry_middleware": "^2.10",
     "guzzlehttp/guzzle": "^7.8",
     "jms/serializer": "^3.30"
   },
   "require-dev": {
     "laravel/pint": "^1.16",
-    "phpunit/phpunit": "^10.5",
-    "phpstan/phpstan": "^1.11"
+    "phpbench/phpbench": "^1.3",
+    "phpstan/phpstan": "^1.11",
+    "phpunit/phpunit": "^10.5"
   },
   "config": {
     "sort-packages": true

--- a/src/Common/Middleware/AddDefaultQueryParamsMiddleware.php
+++ b/src/Common/Middleware/AddDefaultQueryParamsMiddleware.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\RequestInterface;
 /**
  * @internal
  */
-class AddDefaultQueryParamsMiddleware
+final class AddDefaultQueryParamsMiddleware
 {
     public function __construct(
         private readonly string $defaultQuery,

--- a/src/Common/Middleware/AddDefaultQueryParamsMiddleware.php
+++ b/src/Common/Middleware/AddDefaultQueryParamsMiddleware.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Common\Middleware;
+
+use GuzzleHttp\Psr7\Query;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * @internal
+ */
+class AddDefaultQueryParamsMiddleware
+{
+    public function __construct(
+        private readonly string $defaultQuery,
+    ) {}
+
+    public function __invoke(callable $handler): \Closure
+    {
+        return function (RequestInterface $request, array $options) use ($handler) {
+            $newUri = $request->getUri()->withQuery(
+                Query::build([
+                    ...Query::parse($this->defaultQuery),
+                    ...Query::parse($request->getUri()->getQuery()),
+                ]),
+            );
+
+            return $handler($request->withUri($newUri), $options);
+        };
+    }
+}

--- a/src/Common/Middleware/AddXMsClientRequestIdMiddleware.php
+++ b/src/Common/Middleware/AddXMsClientRequestIdMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Common\Middleware;
+
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * @internal
+ */
+class AddXMsClientRequestIdMiddleware
+{
+    public function __invoke(callable $handler): \Closure
+    {
+        return function (RequestInterface $request, array $options) use ($handler) {
+            if ($request->hasHeader('x-ms-client-request-id')) {
+                $request = $request->withHeader('x-ms-version', uniqid(more_entropy: true));
+            }
+
+            return $handler($request, $options);
+        };
+    }
+}

--- a/src/Common/Middleware/AddXMsClientRequestIdMiddleware.php
+++ b/src/Common/Middleware/AddXMsClientRequestIdMiddleware.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\RequestInterface;
 /**
  * @internal
  */
-class AddXMsClientRequestIdMiddleware
+final class AddXMsClientRequestIdMiddleware
 {
     public function __invoke(callable $handler): \Closure
     {

--- a/src/Common/Middleware/ClientFactory.php
+++ b/src/Common/Middleware/ClientFactory.php
@@ -9,19 +9,21 @@ use AzureOss\Storage\Common\Auth\StorageSharedKeyCredential;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleRetry\GuzzleRetryMiddleware;
+use Psr\Http\Message\UriInterface;
 
 /**
  * @internal
  */
 final class ClientFactory
 {
-    public function create(?StorageSharedKeyCredential $sharedKeyCredential): Client
+    public function create(UriInterface $uri, ?StorageSharedKeyCredential $sharedKeyCredential): Client
     {
         $handlerStack = HandlerStack::create();
 
         $handlerStack->push(new AddXMsClientRequestIdMiddleware());
         $handlerStack->push(new AddXMsDateHeaderMiddleware());
         $handlerStack->push(new AddXMsVersionMiddleware(ApiVersion::LATEST));
+        $handlerStack->push(new AddDefaultQueryParamsMiddleware($uri->getQuery()));
 
         if ($sharedKeyCredential !== null) {
             $handlerStack->push(new AddAuthorizationHeaderMiddleware($sharedKeyCredential));

--- a/tests/Blob/BlobFeatureTestCase.php
+++ b/tests/Blob/BlobFeatureTestCase.php
@@ -8,7 +8,7 @@ use AzureOss\Storage\Blob\BlobServiceClient;
 use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 
-class BlobFeatureTestCase extends TestCase
+abstract class BlobFeatureTestCase extends TestCase
 {
     protected BlobServiceClient $serviceClient;
 


### PR DESCRIPTION
This PR adds 3 middlewares
* one for setting a request id. This can be useful for debugging
* one for merging default query (like sas) with the existing
* a retry middleware

I opted to use an already existing package for retrying
* it's a very popular package (5 mil downloads)
* it respects the Retry-After headers if you send too much requests
* it supports callbacks on failure. This can be useful if we add secondary url support.