### PR TITLE
Fix duplicate slashes in path in BlobContainerClient

### DIFF
--- a/src/Blob/BlobContainerClient.php
+++ b/src/Blob/BlobContainerClient.php
@@ -50,7 +50,7 @@ final class BlobContainerClient
     public function getBlobClient(string $blobName): BlobClient
     {
         return new BlobClient(
-            $this->uri->withPath($this->uri->getPath() . "/" . $blobName),
+            $this->uri->withPath($this->uri->getPath() . "/" . ltrim($blobName, "/")),
             $this->sharedKeyCredentials,
         );
     }

--- a/tests/Blob/Feature/BlobContainerClientTest.php
+++ b/tests/Blob/Feature/BlobContainerClientTest.php
@@ -335,6 +335,18 @@ final class BlobContainerClientTest extends BlobFeatureTestCase
     }
 
     #[Test]
+    public function filter_duplicate_slashes_in_path(): void
+    {
+        $containerClient = $this->serviceClient->getContainerClient($this->randomContainerName());
+
+        $randomContainer = 'randomContainer';
+        $withoutSlash = $containerClient->getBlobClient($randomContainer);
+        $withSlash = $containerClient->getBlobClient('/' . $randomContainer);
+
+        self::assertEquals($withoutSlash->uri, $withSlash->uri);
+    }
+
+    #[Test]
     public function find_blobs_by_tag_works(): void
     {
         $this->markTestSkippedWhenUsingSimulator();


### PR DESCRIPTION
Fix bug where duplicate slashes are added.

Especially by (for example) https://github.com/Azure-OSS/azure-storage-php-adapter-flysystem/blob/main/src/AzureBlobStorageAdapter.php#L57