### PR TITLE
Removed the restriction on unknown sized streams

### DIFF
--- a/src/Blob/BlobClient.php
+++ b/src/Blob/BlobClient.php
@@ -239,7 +239,7 @@ final class BlobClient
                     'blockid' => base64_encode($block->id),
                 ],
                 'headers' => [
-                    'Content-Length' => is_string($content) ? mb_strlen($content) : $content->getSize(),
+                    'Content-Length' => is_string($content) ? strlen($content) : $content->getSize(),
                 ],
                 'body' => $content,
             ]);

--- a/src/Blob/BlobClient.php
+++ b/src/Blob/BlobClient.php
@@ -8,7 +8,6 @@ use AzureOss\Storage\Blob\Exceptions\BlobNotFoundException;
 use AzureOss\Storage\Blob\Exceptions\BlobStorageExceptionFactory;
 use AzureOss\Storage\Blob\Exceptions\InvalidBlobUriException;
 use AzureOss\Storage\Blob\Exceptions\UnableToGenerateSasException;
-use AzureOss\Storage\Blob\Exceptions\UnableToUploadBlobException;
 use AzureOss\Storage\Blob\Helpers\BlobUriParserHelper;
 use AzureOss\Storage\Blob\Helpers\MetadataHelper;
 use AzureOss\Storage\Blob\Models\BlobDownloadStreamingResult;
@@ -140,11 +139,7 @@ final class BlobClient
         $content = StreamUtils::streamFor($content);
         $contentLength = $content->getSize();
 
-        if ($contentLength === null) {
-            throw new UnableToUploadBlobException();
-        }
-
-        if ($contentLength <= $options->initialTransferSize) {
+        if ($contentLength !== null && $contentLength <= $options->initialTransferSize) {
             $this->uploadSingle($content, $options);
         } else {
             $this->uploadInBlocks($content, $options);

--- a/src/Blob/BlobClient.php
+++ b/src/Blob/BlobClient.php
@@ -139,7 +139,7 @@ final class BlobClient
         $content = StreamUtils::streamFor($content);
         $contentLength = $content->getSize();
 
-        if ($contentLength !== null && $contentLength <= $options->initialTransferSize) {
+        if (!$content->isSeekable() || $contentLength !== null && $contentLength <= $options->initialTransferSize) {
             $this->uploadSingle($content, $options);
         } else {
             $this->uploadInBlocks($content, $options);

--- a/src/Blob/BlobClient.php
+++ b/src/Blob/BlobClient.php
@@ -176,9 +176,9 @@ final class BlobClient
                 break;
             }
 
-            $blockId = str_pad((string) count($blocks), 6, '0', STR_PAD_LEFT);
-            $block = new Block($blockId, BlockType::UNCOMMITTED);
+            $block = new Block(count($blocks), BlockType::UNCOMMITTED);
             $blocks[] = $block;
+
             hash_update($contextMD5, $blockContent);
 
             $this->putBlockAsync($block, $blockContent)->wait();
@@ -206,8 +206,7 @@ final class BlobClient
                     break;
                 }
 
-                $blockId = str_pad((string) count($blocks), 6, '0', STR_PAD_LEFT);
-                $block = new Block($blockId, BlockType::UNCOMMITTED);
+                $block = new Block(count($blocks), BlockType::UNCOMMITTED);
                 $blocks[] = $block;
 
                 yield fn() => $this->putBlockAsync($block, $blockContent);
@@ -236,7 +235,7 @@ final class BlobClient
             ->putAsync($this->uri, [
                 'query' => [
                     'comp' => 'block',
-                    'blockid' => base64_encode($block->id),
+                    'blockid' => $block->getId(),
                 ],
                 'headers' => [
                     'Content-Length' => is_string($content) ? strlen($content) : $content->getSize(),

--- a/src/Blob/Exceptions/UnableToUploadBlobException.php
+++ b/src/Blob/Exceptions/UnableToUploadBlobException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Blob\Exceptions;
+
+/**
+ * @deprecated Uploading a blob will no longer throw this
+ */
+final class UnableToUploadBlobException extends \Exception {}

--- a/src/Blob/Exceptions/UnableToUploadBlobException.php
+++ b/src/Blob/Exceptions/UnableToUploadBlobException.php
@@ -1,7 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace AzureOss\Storage\Blob\Exceptions;
-
-final class UnableToUploadBlobException extends \Exception {}

--- a/src/Blob/Requests/Block.php
+++ b/src/Blob/Requests/Block.php
@@ -10,7 +10,12 @@ namespace AzureOss\Storage\Blob\Requests;
 final class Block
 {
     public function __construct(
-        public string $id,
+        public int $number,
         public BlockType $type,
     ) {}
+
+    public function getId(): string
+    {
+        return base64_encode(str_pad((string) $this->number, 6, '0', STR_PAD_LEFT));
+    }
 }

--- a/src/Blob/Requests/PutBlockRequestBody.php
+++ b/src/Blob/Requests/PutBlockRequestBody.php
@@ -21,7 +21,7 @@ final class PutBlockRequestBody
         $xml = new \SimpleXMLElement("<BlockList></BlockList>");
 
         foreach ($this->blocks as $block) {
-            $xml->addChild($block->type->value, base64_encode($block->id));
+            $xml->addChild($block->type->value, $block->getId());
         }
 
         return $xml;

--- a/tests/Blob/Feature/BlobClientTest.php
+++ b/tests/Blob/Feature/BlobClientTest.php
@@ -13,6 +13,7 @@ use AzureOss\Storage\Blob\Models\UploadBlobOptions;
 use AzureOss\Storage\Blob\Sas\BlobSasBuilder;
 use AzureOss\Storage\Blob\Sas\BlobSasPermissions;
 use AzureOss\Storage\Tests\Blob\BlobFeatureTestCase;
+use GuzzleHttp\Psr7\NoSeekStream;
 use GuzzleHttp\Psr7\StreamDecoratorTrait;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\StreamInterface;
@@ -214,6 +215,29 @@ final class BlobClientTest extends BlobFeatureTestCase
                     return null;
                 }
             };
+
+            $beforeUploadContent = $file->getContents();
+            $file->rewind();
+
+            $this->blobClient->upload($stream, new UploadBlobOptions("text/plain", initialTransferSize: 500, maximumTransferSize: 100));
+
+            $properties = $this->blobClient->getProperties();
+
+            self::assertEquals("text/plain", $properties->contentType);
+            self::assertEquals(1000, $properties->contentLength);
+
+            $blob = $this->blobClient->downloadStreaming();
+
+            self::assertEquals($beforeUploadContent, $blob->content);
+            self::assertEquals(md5($beforeUploadContent), $blob->properties->contentMD5);
+        });
+    }
+
+    #[Test]
+    public function upload_works_with_non_seekable_stream(): void
+    {
+        $this->withFile(1000, function (StreamInterface $file) {
+            $stream = new NoSeekStream($file);
 
             $beforeUploadContent = $file->getContents();
             $file->rewind();

--- a/tests/Blob/Feature/BlobClientTest.php
+++ b/tests/Blob/Feature/BlobClientTest.php
@@ -13,6 +13,7 @@ use AzureOss\Storage\Blob\Models\UploadBlobOptions;
 use AzureOss\Storage\Blob\Sas\BlobSasBuilder;
 use AzureOss\Storage\Blob\Sas\BlobSasPermissions;
 use AzureOss\Storage\Tests\Blob\BlobFeatureTestCase;
+use GuzzleHttp\Psr7\StreamDecoratorTrait;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\StreamInterface;
 
@@ -188,6 +189,36 @@ final class BlobClientTest extends BlobFeatureTestCase
             $file->rewind();
 
             $this->blobClient->upload($file, new UploadBlobOptions("text/plain", initialTransferSize: 500, maximumTransferSize: 100));
+
+            $properties = $this->blobClient->getProperties();
+
+            self::assertEquals("text/plain", $properties->contentType);
+            self::assertEquals(1000, $properties->contentLength);
+
+            $blob = $this->blobClient->downloadStreaming();
+
+            self::assertEquals($beforeUploadContent, $blob->content);
+            self::assertEquals(md5($beforeUploadContent), $blob->properties->contentMD5);
+        });
+    }
+
+    #[Test]
+    public function upload_works_with_unknown_sized_stream(): void
+    {
+        $this->withFile(1000, function (StreamInterface $file) {
+            $stream = new class ($file) implements StreamInterface {
+                use StreamDecoratorTrait;
+
+                public function getSize(): ?int
+                {
+                    return null;
+                }
+            };
+
+            $beforeUploadContent = $file->getContents();
+            $file->rewind();
+
+            $this->blobClient->upload($stream, new UploadBlobOptions("text/plain", initialTransferSize: 500, maximumTransferSize: 100));
 
             $properties = $this->blobClient->getProperties();
 


### PR DESCRIPTION
Hi,

I've been working with the package and streaming data, and it includes this exception which is thrown when the size of the stream is unknown. However, the code for `uploadInBlocks` works fine with an unknown size stream. Is there a reason this is here?

If not, this PR removes the restriction and adds a test for a stream where the size cannot be determined.