### PR TITLE
Set the stream chunk size to the initial transfer size

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup node for the mock server
+        uses: actions/setup-node@v4
+
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2
         with:

--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,12 @@
     "guzzlehttp/guzzle": "^7.8"
   },
   "require-dev": {
+    "guzzlehttp/test-server": "^0.1.0",
     "laravel/pint": "1.20.0",
     "phpbench/phpbench": "^1.3",
     "phpstan/phpstan": "^2.0",
-    "phpstan/phpstan-strict-rules": "^2.0",
     "phpstan/phpstan-deprecation-rules": "^2.0",
+    "phpstan/phpstan-strict-rules": "^2.0",
     "phpunit/phpunit": "^10.5"
   },
   "config": {

--- a/src/Blob/BlobClient.php
+++ b/src/Blob/BlobClient.php
@@ -141,7 +141,7 @@ final class BlobClient
         }
 
         if (is_resource($content)) {
-            stream_set_chunk_size($content, $options->initialTransferSize);
+            stream_set_chunk_size($content, $options->maximumTransferSize);
         }
 
         $content = StreamUtils::streamFor($content);

--- a/src/Blob/BlobClient.php
+++ b/src/Blob/BlobClient.php
@@ -136,6 +136,14 @@ final class BlobClient
             $options = new UploadBlobOptions();
         }
 
+        if ($content instanceof StreamInterface) {
+            $content = $content->detach();
+        }
+
+        if (is_resource($content)) {
+            stream_set_chunk_size($content, $options->initialTransferSize);
+        }
+
         $content = StreamUtils::streamFor($content);
 
         if ($content->getSize() === null || ! $content->isSeekable()) {

--- a/src/Blob/BlobClient.php
+++ b/src/Blob/BlobClient.php
@@ -136,7 +136,7 @@ final class BlobClient
             $options = new UploadBlobOptions();
         }
 
-        $content = StreamUtils::streamFor($content);
+        $content = $this->createUploadStream($content, $options);
 
         if ($content->getSize() === null || ! $content->isSeekable()) {
             $this->uploadInSequentialBlocks($content, $options);
@@ -145,6 +145,23 @@ final class BlobClient
         } else {
             $this->uploadSingle($content, $options);
         }
+    }
+
+    /**
+     * @param string|resource|StreamInterface $content
+     */
+    private function createUploadStream($content, UploadBlobOptions $options): StreamInterface
+    {
+        if ($content instanceof StreamInterface) {
+            $content = $content->detach();
+        }
+
+        // fix network streams only reading 8KB chunks
+        if (is_resource($content)) {
+            stream_set_chunk_size($content, $options->maximumTransferSize);
+        }
+
+        return StreamUtils::streamFor($content);
     }
 
     private function uploadSingle(StreamInterface $content, UploadBlobOptions $options): void

--- a/tests/Blob/BlobFeatureTestCase.php
+++ b/tests/Blob/BlobFeatureTestCase.php
@@ -6,7 +6,6 @@ namespace AzureOss\Storage\Tests\Blob;
 
 use AzureOss\Storage\Blob\BlobServiceClient;
 use AzureOss\Storage\Blob\Helpers\BlobUriParserHelper;
-use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 
 abstract class BlobFeatureTestCase extends TestCase
@@ -38,26 +37,6 @@ abstract class BlobFeatureTestCase extends TestCase
         foreach ($containerClient->getBlobs() as $blob) {
             $containerClient->getBlobClient($blob->name)->delete();
         }
-    }
-
-    protected function withFile(int $size, callable $callable): void
-    {
-        $path = sys_get_temp_dir() . '/azure-oss-test-file';
-
-        unlink($path);
-        $resource = Utils::streamFor(Utils::tryFopen($path, 'w'));
-
-        $chunk = 1000;
-        while ($size > 0) {
-            $chunkContent = str_pad('', min($chunk, $size));
-            $resource->write($chunkContent);
-            $size -= $chunk;
-        }
-        $resource->close();
-
-        $callable(Utils::streamFor(Utils::tryFopen($path, 'r')));
-
-        unlink($path);
     }
 
     protected function markTestSkippedWhenUsingSimulator(): void

--- a/tests/Blob/Feature/BlobClientTest.php
+++ b/tests/Blob/Feature/BlobClientTest.php
@@ -13,8 +13,10 @@ use AzureOss\Storage\Blob\Models\UploadBlobOptions;
 use AzureOss\Storage\Blob\Sas\BlobSasBuilder;
 use AzureOss\Storage\Blob\Sas\BlobSasPermissions;
 use AzureOss\Storage\Tests\Blob\BlobFeatureTestCase;
+use AzureOss\Storage\Tests\Utils\FileFactory;
 use GuzzleHttp\Psr7\NoSeekStream;
 use GuzzleHttp\Psr7\StreamDecoratorTrait;
+use GuzzleHttp\Server\Server;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\StreamInterface;
 
@@ -29,6 +31,11 @@ final class BlobClientTest extends BlobFeatureTestCase
         $this->containerClient = $this->serviceClient->getContainerClient("blobclient");
         $this->blobClient = $this->containerClient->getBlobClient("some/file.txt");
         $this->cleanContainer($this->containerClient->containerName);
+    }
+
+    protected function tearDown(): void
+    {
+        Server::stop();
     }
 
     #[Test]
@@ -165,7 +172,7 @@ final class BlobClientTest extends BlobFeatureTestCase
     #[Test]
     public function upload_works_with_single_upload(): void
     {
-        $this->withFile(1000, function (StreamInterface $file) {
+        FileFactory::withStream(1000, function (StreamInterface $file) {
             $beforeUploadContent = $file->getContents();
             $file->rewind();
 
@@ -185,7 +192,7 @@ final class BlobClientTest extends BlobFeatureTestCase
     #[Test]
     public function upload_works_with_parallel_upload(): void
     {
-        $this->withFile(1000, function (StreamInterface $file) {
+        FileFactory::withStream(1000, function (StreamInterface $file) {
             $beforeUploadContent = $file->getContents();
             $file->rewind();
 
@@ -206,7 +213,7 @@ final class BlobClientTest extends BlobFeatureTestCase
     #[Test]
     public function upload_works_with_unknown_sized_stream(): void
     {
-        $this->withFile(1000, function (StreamInterface $file) {
+        FileFactory::withStream(1000, function (StreamInterface $file) {
             $stream = new class ($file) implements StreamInterface {
                 use StreamDecoratorTrait;
 
@@ -236,7 +243,7 @@ final class BlobClientTest extends BlobFeatureTestCase
     #[Test]
     public function upload_works_with_non_seekable_stream(): void
     {
-        $this->withFile(1000, function (StreamInterface $file) {
+        FileFactory::withStream(1000, function (StreamInterface $file) {
             $stream = new NoSeekStream($file);
 
             $beforeUploadContent = $file->getContents();

--- a/tests/Blob/Feature/BlobClientTest.php
+++ b/tests/Blob/Feature/BlobClientTest.php
@@ -33,11 +33,6 @@ final class BlobClientTest extends BlobFeatureTestCase
         $this->cleanContainer($this->containerClient->containerName);
     }
 
-    protected function tearDown(): void
-    {
-        Server::stop();
-    }
-
     #[Test]
     public function download_stream_works(): void
     {

--- a/tests/Blob/Feature/BlobClientTest.php
+++ b/tests/Blob/Feature/BlobClientTest.php
@@ -16,7 +16,6 @@ use AzureOss\Storage\Tests\Blob\BlobFeatureTestCase;
 use AzureOss\Storage\Tests\Utils\FileFactory;
 use GuzzleHttp\Psr7\NoSeekStream;
 use GuzzleHttp\Psr7\StreamDecoratorTrait;
-use GuzzleHttp\Server\Server;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\StreamInterface;
 

--- a/tests/Blob/Feature/MockBlobClientTest.php
+++ b/tests/Blob/Feature/MockBlobClientTest.php
@@ -39,43 +39,57 @@ class MockBlobClientTest extends TestCase
     #[Test]
     public function upload_single_sends_correct_amount_of_requests(): void
     {
-        Server::enqueue(array_fill(0, 1000, new Response(200)));
+        $this->expectNotToPerformAssertions();
+
+        Server::enqueue([
+            new Response(200), // only one request
+            new Response(501), // fail if more requests
+        ]);
 
         FileFactory::withStream(1000, function (StreamInterface $file) {
             $this->mockBlobClient->upload($file, new UploadBlobOptions("text/plain", initialTransferSize: 2000));
         });
-
-        self::assertCount(1, Server::received());
     }
 
     #[Test]
     public function upload_parallel_blocks_sends_correct_amount_of_requests(): void
     {
-        Server::enqueue(array_fill(0, 1000, new Response(200)));
+        $this->expectNotToPerformAssertions(); // should not throw because of the 501
+
+        Server::enqueue([
+            ...array_fill(0, 11, new Response(200)), // 10 chunks + 1 commit request
+            new Response(501), // fail if more requests
+        ]);
 
         FileFactory::withStream(50_000_000, function (StreamInterface $file) {
-            $this->mockBlobClient->upload($file, new UploadBlobOptions("text/plain", initialTransferSize: 0, maximumTransferSize: 3_000_000));
+            $this->mockBlobClient->upload($file, new UploadBlobOptions("text/plain", initialTransferSize: 0, maximumTransferSize: 5_000_000));
         });
-
-        self::assertCount(18, Server::received()); // 50kb in 3kb chunks => 17 requests + final request = 18
     }
 
     #[Test]
     public function upload_parallel_blocks_sends_correct_amount_of_requests_for_small_files(): void
     {
-        Server::enqueue(array_fill(0, 1000, new Response(200)));
+        $this->expectNotToPerformAssertions(); // should not throw because of the 501
+
+        Server::enqueue([
+            ...array_fill(0, 2, new Response(200)), // 1 chunks + 1 commit request
+            new Response(501), // fail if more requests
+        ]);
 
         FileFactory::withStream(50_000, function (StreamInterface $file) {
             $this->mockBlobClient->upload($file, new UploadBlobOptions("text/plain", initialTransferSize: 0, maximumTransferSize: 8_000_000));
         });
-
-        self::assertCount(2, Server::received()); // 50kb in 8MB chunks => 1 request + final request = 2
     }
 
     #[Test]
     public function upload_sequential_blocks_sends_correct_amount_of_requests(): void
     {
-        Server::enqueue(array_fill(0, 1000, new Response(200)));
+        $this->expectNotToPerformAssertions(); // should not throw because of the 501
+
+        Server::enqueue([
+            ...array_fill(0, 11, new Response(200)), // 10 chunks + 1 commit request
+            new Response(501), // fail if more requests
+        ]);
 
         FileFactory::withStream(50_000_000, function (StreamInterface $file) {
             $stream = new class ($file) implements StreamInterface {
@@ -87,9 +101,23 @@ class MockBlobClientTest extends TestCase
                 }
             };
 
-            $this->mockBlobClient->upload($stream, new UploadBlobOptions("text/plain", initialTransferSize: 0, maximumTransferSize: 3_000_000));
+            $this->mockBlobClient->upload($stream, new UploadBlobOptions("text/plain", initialTransferSize: 0, maximumTransferSize: 5_000_000));
         });
+    }
 
-        self::assertCount(18, Server::received()); // 50kb in 3kb chunks => 17 requests + final request = 18
+    #[Test]
+    public function upload_parallel_blocks_sends_correct_amount_of_requests_with_a_network_request(): void
+    {
+        $this->expectNotToPerformAssertions(); // should not throw because of the 501
+
+        Server::enqueue([
+            new Response(200, body: str_repeat('X', 50_000_000)), // stream for fopen
+            ...array_fill(0, 20, new Response(200)), // with network streams some chunks in the beginning are smaller. It should be less than 20 requests still.
+            new Response(501), // fail if more requests
+        ]);
+
+        $stream = fopen(Server::$url, 'r');
+
+        $this->mockBlobClient->upload($stream, new UploadBlobOptions("text/plain", initialTransferSize: 0, maximumTransferSize: 5_000_000));
     }
 }

--- a/tests/Blob/Feature/MockBlobClientTest.php
+++ b/tests/Blob/Feature/MockBlobClientTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Tests\Blob\Feature;
+
+use AzureOss\Storage\Blob\BlobClient;
+use AzureOss\Storage\Blob\BlobServiceClient;
+use AzureOss\Storage\Blob\Models\UploadBlobOptions;
+use AzureOss\Storage\Tests\Utils\FileFactory;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\StreamDecoratorTrait;
+use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Server\Server;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\StreamInterface;
+
+class MockBlobClientTest extends TestCase
+{
+    private BlobClient $mockBlobClient;
+
+    protected function setUp(): void
+    {
+        Server::start();
+
+        /** @phpstan-ignore-next-line */
+        $uri = new Uri(Server::$url . '/devstoreaccount1');
+        $mockServiceClient = new BlobServiceClient($uri);
+        $mockContainerClient = $mockServiceClient->getContainerClient('test');
+        $this->mockBlobClient = $mockContainerClient->getBlobClient('test');
+    }
+
+    protected function tearDown(): void
+    {
+        Server::stop();
+    }
+
+    #[Test]
+    public function upload_single_sends_correct_amount_of_requests(): void
+    {
+        Server::enqueue(array_fill(0, 1000, new Response(200)));
+
+        FileFactory::withStream(1000, function (StreamInterface $file) {
+            $this->mockBlobClient->upload($file, new UploadBlobOptions("text/plain", initialTransferSize: 2000));
+        });
+
+        self::assertCount(1, Server::received());
+    }
+
+    #[Test]
+    public function upload_parallel_blocks_sends_correct_amount_of_requests(): void
+    {
+        Server::enqueue(array_fill(0, 1000, new Response(200)));
+
+        FileFactory::withStream(50_000_000, function (StreamInterface $file) {
+            $this->mockBlobClient->upload($file, new UploadBlobOptions("text/plain", initialTransferSize: 0, maximumTransferSize: 3_000_000));
+        });
+
+        self::assertCount(18, Server::received()); // 50kb in 3kb chunks => 17 requests + final request = 18
+    }
+
+    #[Test]
+    public function upload_sequential_blocks_sends_correct_amount_of_requests(): void
+    {
+        Server::enqueue(array_fill(0, 1000, new Response(200)));
+
+        FileFactory::withStream(50_000_000, function (StreamInterface $file) {
+            $stream = new class ($file) implements StreamInterface {
+                use StreamDecoratorTrait;
+
+                public function getSize(): ?int
+                {
+                    return null;
+                }
+            };
+
+            $this->mockBlobClient->upload($stream, new UploadBlobOptions("text/plain", initialTransferSize: 0, maximumTransferSize: 3_000_000));
+        });
+
+        self::assertCount(18, Server::received()); // 50kb in 3kb chunks => 17 requests + final request = 18
+    }
+}

--- a/tests/Utils/FileFactory.php
+++ b/tests/Utils/FileFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Tests\Utils;
+
+use GuzzleHttp\Psr7\Utils;
+
+final class FileFactory
+{
+    public static function withStream(int $size, callable $callable): void
+    {
+        $path = sys_get_temp_dir() . '/azure-oss-test-file';
+
+        unlink($path);
+        $resource = Utils::streamFor(Utils::tryFopen($path, 'w'));
+
+        $chunk = 1000;
+        while ($size > 0) {
+            $chunkContent = str_pad('', min($chunk, $size));
+            $resource->write($chunkContent);
+            $size -= $chunk;
+        }
+        $resource->close();
+
+        $callable(Utils::streamFor(Utils::tryFopen($path, 'r')));
+
+        unlink($path);
+    }
+}


### PR DESCRIPTION
Hi,

I discovered an issue when uploading larger files via the streaming method, that the internal stream chunk size being used by the stream from guzzle was 8k (despite the size requested in fread). So each block being pushed to Azure was 8k.

This PR changes the stream chunk size to the initial transfer size, so when the system `freads`, it actually receives the number of bytes requested.

https://www.php.net/manual/en/function.stream-set-chunk-size.php

Using a 39KB file...

Before:

```
2025-02-05T09:20:29.713911721Z 172.19.0.1 - - [05/Feb/2025:09:20:29 +0000] "PUT /devstoreaccount1/fourfour/cMJu3BWYXjIq9FFAIwHtwzK4qJFbZQYTkdEItjmr.jpg?comp=block&blockid=MDAwMDAw HTTP/1.1" 201 -
2025-02-05T09:20:29.722053054Z 172.19.0.1 - - [05/Feb/2025:09:20:29 +0000] "PUT /devstoreaccount1/fourfour/cMJu3BWYXjIq9FFAIwHtwzK4qJFbZQYTkdEItjmr.jpg?comp=block&blockid=MDAwMDAx HTTP/1.1" 201 -
2025-02-05T09:20:29.732805054Z 172.19.0.1 - - [05/Feb/2025:09:20:29 +0000] "PUT /devstoreaccount1/fourfour/cMJu3BWYXjIq9FFAIwHtwzK4qJFbZQYTkdEItjmr.jpg?comp=block&blockid=MDAwMDAy HTTP/1.1" 201 -
2025-02-05T09:20:29.740879971Z 172.19.0.1 - - [05/Feb/2025:09:20:29 +0000] "PUT /devstoreaccount1/fourfour/cMJu3BWYXjIq9FFAIwHtwzK4qJFbZQYTkdEItjmr.jpg?comp=block&blockid=MDAwMDAz HTTP/1.1" 201 -
2025-02-05T09:20:29.765989221Z 172.19.0.1 - - [05/Feb/2025:09:20:29 +0000] "PUT /devstoreaccount1/fourfour/cMJu3BWYXjIq9FFAIwHtwzK4qJFbZQYTkdEItjmr.jpg?comp=blocklist HTTP/1.1" 201 -
```


After:

```
2025-02-05T09:17:47.356302257Z 172.19.0.1 - - [05/Feb/2025:09:17:47 +0000] "PUT /devstoreaccount1/fourfour/z8YQjI1YJVirZXhbxLR3lbGNGbRA6qhqC7rygTaJ.jpg?comp=block&blockid=MDAwMDAw HTTP/1.1" 201 -
2025-02-05T09:17:47.387834007Z 172.19.0.1 - - [05/Feb/2025:09:17:47 +0000] "PUT /devstoreaccount1/fourfour/z8YQjI1YJVirZXhbxLR3lbGNGbRA6qhqC7rygTaJ.jpg?comp=blocklist HTTP/1.1" 201 -
```