### PR TITLE
add async methods

### DIFF
--- a/src/Blob/BlobClient.php
+++ b/src/Blob/BlobClient.php
@@ -22,9 +22,7 @@ use AzureOss\Storage\Common\Auth\StorageSharedKeyCredential;
 use AzureOss\Storage\Common\Middleware\ClientFactory;
 use AzureOss\Storage\Common\Sas\SasProtocol;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Pool;
-use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\Utils as StreamUtils;
@@ -332,7 +330,7 @@ final class BlobClient
                     'x-ms-blob-content-md5' => base64_encode($contentMD5),
                 ],
                 'body' => (new PutBlockRequestBody($blocks))->toXml()->asXML(),
-        ]);
+            ]);
     }
 
     public function copyFromUri(UriInterface $source): void

--- a/src/Blob/BlobClient.php
+++ b/src/Blob/BlobClient.php
@@ -64,7 +64,6 @@ final class BlobClient
                 'stream' => true,
             ])
             ->then(BlobDownloadStreamingResult::fromResponse(...));
-        //            ->otherwise(fn(\Throwable $e) => throw $this->exceptionFactory->create($e));
     }
 
     public function getProperties(): BlobProperties
@@ -78,7 +77,6 @@ final class BlobClient
         return $this->client
             ->headAsync($this->uri)
             ->then(BlobProperties::fromResponseHeaders(...));
-        //            ->otherwise(fn(\Throwable $e) => throw $this->exceptionFactory->create($e));
     }
 
     /**
@@ -101,7 +99,6 @@ final class BlobClient
                 ],
                 'headers' => MetadataHelper::metadataToHeaders($metadata),
             ]);
-        //            ->otherwise(fn(\Throwable $e) => throw $this->exceptionFactory->create($e));
     }
 
     public function delete(): void
@@ -112,7 +109,6 @@ final class BlobClient
     public function deleteAsync(): PromiseInterface
     {
         return $this->client->deleteAsync($this->uri);
-        //            ->otherwise(fn(\Throwable $e) => throw $this->exceptionFactory->create($e));
     }
 
     public function deleteIfExists(): void
@@ -193,7 +189,6 @@ final class BlobClient
                 ],
                 'body' => $content,
             ]);
-        //            ->otherwise(fn(\Throwable $e) => throw $this->exceptionFactory->create($e));
     }
 
     private function uploadInSequentialBlocksAsync(StreamInterface $content, UploadBlobOptions $options): PromiseInterface
@@ -232,7 +227,6 @@ final class BlobClient
                     );
                 },
             );
-        //            ->otherwise(fn(\Throwable $e) => throw $this->exceptionFactory->create($e));
     }
 
     private function uploadInParallelBlocksAsync(StreamInterface $content, UploadBlobOptions $options): PromiseInterface
@@ -271,7 +265,6 @@ final class BlobClient
                     );
                 },
             );
-        //            ->otherwise(fn(\Throwable $e) => throw $this->exceptionFactory->create($e));
     }
 
     private function putBlockAsync(Block $block, StreamInterface|string $content): PromiseInterface
@@ -320,7 +313,6 @@ final class BlobClient
                     'x-ms-copy-source' => (string) $source,
                 ],
             ]);
-        //            ->otherwise(fn(\Throwable $e) => throw $this->exceptionFactory->create($e));
     }
 
     public function generateSasUri(BlobSasBuilder $blobSasBuilder): UriInterface
@@ -361,7 +353,6 @@ final class BlobClient
                 ],
                 'body' => (new BlobTagsBody($tags))->toXml()->asXML(),
             ]);
-        //            ->otherwise(fn(\Throwable $e) => throw $this->exceptionFactory->create($e));
     }
 
     /**
@@ -384,6 +375,5 @@ final class BlobClient
             ->then(
                 fn(ResponseInterface $response) => BlobTagsBody::fromXml(new \SimpleXMLElement($response->getBody()->getContents()))->tags,
             );
-        //            ->otherwise(fn(\Throwable $e) => throw $this->exceptionFactory->create($e));
     }
 }

--- a/src/Blob/BlobContainerClient.php
+++ b/src/Blob/BlobContainerClient.php
@@ -117,7 +117,7 @@ final class BlobContainerClient
     public function exists(): bool
     {
         /** @phpstan-ignore-next-line */
-       return $this->existsAsync()->wait();
+        return $this->existsAsync()->wait();
     }
 
     public function existsAsync(): PromiseInterface

--- a/src/Blob/Exceptions/BlobStorageExceptionDeserializer.php
+++ b/src/Blob/Exceptions/BlobStorageExceptionDeserializer.php
@@ -5,20 +5,16 @@ declare(strict_types=1);
 namespace AzureOss\Storage\Blob\Exceptions;
 
 use AzureOss\Storage\Blob\Responses\ErrorResponse;
+use AzureOss\Storage\Common\Exceptions\RequestExceptionDeserializer;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\ResponseInterface;
 
 /**
  * @internal
  */
-final class BlobStorageExceptionFactory
+final class BlobStorageExceptionDeserializer implements RequestExceptionDeserializer
 {
-    public function create(\Throwable $e): \Throwable
-    {
-        return $e instanceof RequestException ? $this->createFromRequestException($e) : $e;
-    }
-
-    private function createFromRequestException(RequestException $e): \Exception
+    public function deserialize(RequestException $e): \Exception
     {
         $response = $e->getResponse();
         if ($response === null) {

--- a/src/Blob/Helpers/StreamHelper.php
+++ b/src/Blob/Helpers/StreamHelper.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Blob\Helpers;
+
+use GuzzleHttp\Psr7\Utils as StreamUtils;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * @internal
+ */
+final class StreamHelper
+{
+    /**
+     * @param string|resource|StreamInterface $content
+     */
+    public static function createUploadStream($content, int $blockSize): StreamInterface
+    {
+        if (is_string($content)) {
+            return self::createUploadStreamFromString($content);
+        }
+
+        if ($content instanceof StreamInterface) {
+            return self::createUploadStreamFromStream($content, $blockSize);
+        }
+
+        return self::createUploadStreamFromResource($content, $blockSize);
+    }
+
+    private static function createUploadStreamFromString(string $content): StreamInterface
+    {
+        return StreamUtils::streamFor($content);
+    }
+
+    private static function createUploadStreamFromStream(StreamInterface $content, int $blockSize): StreamInterface
+    {
+        $detached = $content->detach();
+        if ($detached === null) {
+            return $content;
+        }
+
+        return self::createUploadStreamFromResource($detached, $blockSize);
+    }
+
+    /**
+     * @param resource $content
+     */
+    private static function createUploadStreamFromResource($content, int $blockSize): StreamInterface
+    {
+        stream_set_chunk_size($content, $blockSize);
+
+        return StreamUtils::streamFor($content);
+    }
+}

--- a/src/Blob/Models/BlobDownloadStreamingResult.php
+++ b/src/Blob/Models/BlobDownloadStreamingResult.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AzureOss\Storage\Blob\Models;
 
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
 final class BlobDownloadStreamingResult
@@ -12,4 +13,12 @@ final class BlobDownloadStreamingResult
         public readonly StreamInterface $content,
         public readonly BlobProperties $properties,
     ) {}
+
+    public static function fromResponse(ResponseInterface $response): self
+    {
+        return new self(
+            $response->getBody(),
+            BlobProperties::fromResponseHeaders($response),
+        );
+    }
 }

--- a/src/Common/Exceptions/RequestExceptionDeserializer.php
+++ b/src/Common/Exceptions/RequestExceptionDeserializer.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Common\Exceptions;
+
+use GuzzleHttp\Exception\RequestException;
+
+/**
+ * @internal
+ */
+interface RequestExceptionDeserializer
+{
+    public function deserialize(RequestException $exception): \Exception;
+}

--- a/src/Common/Middleware/ClientFactory.php
+++ b/src/Common/Middleware/ClientFactory.php
@@ -6,6 +6,7 @@ namespace AzureOss\Storage\Common\Middleware;
 
 use AzureOss\Storage\Common\ApiVersion;
 use AzureOss\Storage\Common\Auth\StorageSharedKeyCredential;
+use AzureOss\Storage\Common\Exceptions\RequestExceptionDeserializer;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleRetry\GuzzleRetryMiddleware;
@@ -16,10 +17,11 @@ use Psr\Http\Message\UriInterface;
  */
 final class ClientFactory
 {
-    public function create(UriInterface $uri, ?StorageSharedKeyCredential $sharedKeyCredential): Client
+    public function create(UriInterface $uri, ?StorageSharedKeyCredential $sharedKeyCredential, RequestExceptionDeserializer $exceptionDeserializer): Client
     {
         $handlerStack = HandlerStack::create();
 
+        $handlerStack->before('http_errors', new DeserializeExceptionMiddleware($exceptionDeserializer));
         $handlerStack->push(new AddXMsClientRequestIdMiddleware());
         $handlerStack->push(new AddXMsDateHeaderMiddleware());
         $handlerStack->push(new AddXMsVersionMiddleware(ApiVersion::LATEST));

--- a/src/Common/Middleware/DeserializeExceptionMiddleware.php
+++ b/src/Common/Middleware/DeserializeExceptionMiddleware.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Common\Middleware;
+
+use AzureOss\Storage\Common\Exceptions\RequestExceptionDeserializer;
+use GuzzleHttp\Exception\RequestException;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * @internal
+ */
+final class DeserializeExceptionMiddleware
+{
+    public function __construct(private RequestExceptionDeserializer $exceptionDeserializer) {}
+
+    public function __invoke(callable $handler): \Closure
+    {
+        return function (RequestInterface $request, array $options) use ($handler) {
+            /** @phpstan-ignore-next-line */
+            return $handler($request, $options)
+                ->otherwise(function (\Throwable $e) {
+                    if ($e instanceof RequestException) {
+                        throw $this->exceptionDeserializer->deserialize($e);
+                    }
+
+                    throw $e;
+                });
+        };
+    }
+}

--- a/tests/Blob/Benchmark/BlobClientBench.php
+++ b/tests/Blob/Benchmark/BlobClientBench.php
@@ -43,8 +43,8 @@ final class BlobClientBench
     {
         yield '20x10KB' => ['path' => FileFactory::create(10_000), 'count' => 100];
         yield '10x10MB' => ['path' => FileFactory::create(10_000_000), 'count' => 10];
-        yield '5x100MB' => ['path' => FileFactory::create(100_000_000), 'count' => 1];
-        yield '2x800MB' => ['path' => FileFactory::create(800_000_000), 'count' => 1];
-        yield '1x1.6GB' => ['path' => FileFactory::create(1_600_000_000), 'count' => 1];
+        yield '5x100MB' => ['path' => FileFactory::create(100_000_000), 'count' => 5];
+        yield '2x1GB' => ['path' => FileFactory::create(1_000_000_000), 'count' => 2];
+        yield '1x4GB' => ['path' => FileFactory::create(4_000_000_000), 'count' => 1];
     }
 }

--- a/tests/Blob/Feature/BlobClientTest.php
+++ b/tests/Blob/Feature/BlobClientTest.php
@@ -211,6 +211,11 @@ final class BlobClientTest extends BlobFeatureTestCase
             $stream = new class ($file) implements StreamInterface {
                 use StreamDecoratorTrait;
 
+                public function detach()
+                {
+                    return null;
+                }
+
                 public function getSize(): ?int
                 {
                     return null;
@@ -238,7 +243,14 @@ final class BlobClientTest extends BlobFeatureTestCase
     public function upload_works_with_non_seekable_stream(): void
     {
         FileFactory::withStream(1000, function (StreamInterface $file) {
-            $stream = new NoSeekStream($file);
+            $stream = new class (new NoSeekStream($file)) implements StreamInterface {
+                use StreamDecoratorTrait;
+
+                public function detach()
+                {
+                    return null;
+                }
+            };
 
             $beforeUploadContent = $file->getContents();
             $file->rewind();


### PR DESCRIPTION
Guzzle/promises is separate from the http client, so there is no hard requirement on guzzle. Other SDKs like aws s3 and google cloud also use these promises.

Will add generics once they are added to the promise library.
https://github.com/guzzle/promises/pull/175
https://github.com/guzzle/promises/pull/177