### PR TITLE
Add setProperties method to BlobClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ if ($targetBlobClient->getProperties()->copyStatus === CopyStatus::PENDING) {
 }
 ```
 
+Update blob properties after upload or copy:
+```php
+$targetBlobClient->setHttpHeaders(new BlobHttpHeaders(
+    contentType: "image/jpeg",
+    cacheControl: "public, max-age=3600"
+));
+```
+
 Generate a container [Service SAS](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview#service-sas)
 ```php
 $sas = $containerClient->generateSasUri(

--- a/src/Blob/BlobClient.php
+++ b/src/Blob/BlobClient.php
@@ -15,6 +15,7 @@ use AzureOss\Storage\Blob\Helpers\StreamHelper;
 use AzureOss\Storage\Blob\Models\AbortCopyFromUriOptions;
 use AzureOss\Storage\Blob\Models\BlobCopyResult;
 use AzureOss\Storage\Blob\Models\BlobDownloadStreamingResult;
+use AzureOss\Storage\Blob\Models\BlobHttpHeaders;
 use AzureOss\Storage\Blob\Models\BlobProperties;
 use AzureOss\Storage\Blob\Models\StartCopyFromUriOptions;
 use AzureOss\Storage\Blob\Models\CommitBlockListOptions;
@@ -120,6 +121,27 @@ final class BlobClient
                 ],
                 RequestOptions::HEADERS => MetadataHelper::metadataToHeaders($metadata),
             ]);
+    }
+
+    /**
+     * Sets system properties on the blob
+     *
+     * @see https://learn.microsoft.com/en-us/rest/api/storageservices/set-blob-properties
+     */
+    public function setHttpHeaders(BlobHttpHeaders $httpHeaders): void
+    {
+        $this->setHttpHeadersAsync($httpHeaders)->wait();
+    }
+
+    /**
+     * @see https://learn.microsoft.com/en-us/rest/api/storageservices/set-blob-properties
+     */
+    public function setHttpHeadersAsync(BlobHttpHeaders $httpHeaders): PromiseInterface
+    {
+        return $this->client->putAsync($this->uri, [
+            RequestOptions::QUERY => ['comp' => 'properties'],
+            RequestOptions::HEADERS => $httpHeaders->toArray(),
+        ]);
     }
 
     public function delete(): void


### PR DESCRIPTION
Hi there and thanks for the amazing library! 👋

Adds the Azure Blob Storage Set Blob Properties REST API operation (https://learn.microsoft.com/en-us/rest/api/storageservices/set-blob-properties).

Afaik currently, there's no way to update blob properties like content-type after a blob has been uploaded or copied. For example we have a use case where we store blobs in a private container and copy them to a target container for web delivery and need to set properties like content-type or cache controls.

Cheers!


